### PR TITLE
.github/build_*.yml: migrate JUnit plugin

### DIFF
--- a/.github/workflows/build_JDK11.yml
+++ b/.github/workflows/build_JDK11.yml
@@ -21,6 +21,7 @@ jobs:
         run: mvn -B package --file pom.xml
       - name: Publish Test Report
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v3
         with:
           check_name: JDK11 result
+          report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/build_JDK8.yml
+++ b/.github/workflows/build_JDK8.yml
@@ -21,6 +21,7 @@ jobs:
         run: mvn -B package --file pom.xml
       - name: Publish Test Report
         if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1
+        uses: mikepenz/action-junit-report@v3
         with:
           check_name: JDK8 result
+          report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
from scacap/action-surefire-report@v1 to mikepenz/action-junit-report@v3 because scacap/action-surefire-report@v1 doesn't work well on pull_request